### PR TITLE
Remove cycle on destroy of worker node

### DIFF
--- a/provision/main.tf
+++ b/provision/main.tf
@@ -27,6 +27,10 @@ resource "null_resource" "provision_worker" {
     master_provisioned = "${var.master_provision_dependency}"
   }
 
+  lifecycle{
+    create_before_destroy = true
+  }
+
   count = "${var.worker_count}"
 
   connection {


### PR DESCRIPTION
# Problem
Removing a worker node causes a cycle error in terraform.

# Approach
From [this issue](https://github.com/hashicorp/terraform/issues/2359) it looks like any resource that uses the `create_before_destroy` lifecycle tag has to have that same tag on any resources that it depends on. There weren't any resources with that tag, but it looks like the `when=destroy` tag sets up something similar.

I added a `create_before_destroy` to the `provision_worker` resource and this seems to be fixed now.

# How to test
1. Create a cluster with one worker node
2. Change the number of worker nodes to 2 and terraform apply
3. Change the number of worker nodes to 1 and terraform apply
4. Finally destroy the cluster

These steps should all work as expected