### PR TITLE
GlusterFS Provisioner Support

### DIFF
--- a/06_provision_storage.tf
+++ b/06_provision_storage.tf
@@ -56,12 +56,12 @@ count      = "${var.storage_node_count}"
 
 
 resource "null_resource" "install_nfs" {
-depends_on = [
+  depends_on = [
     "null_resource.provision_storage_mounts",
-]
+  ]
 
-# Don't install if there are no storage nodes in use
-count = "${var.storage_node_count > 0 ? 1 : 0}"
+  # Don't install if there are no storage nodes in use
+  count = "${(var.storage_node_count == 1) ? 1 : 0}"
 
   connection {
     user        = "ubuntu"
@@ -83,6 +83,38 @@ count = "${var.storage_node_count > 0 ? 1 : 0}"
     inline = [
       "chmod +x /home/ubuntu/deploy-nfs.sh",
       "/home/ubuntu/deploy-nfs.sh"
+    ]
+  }
+}
+
+resource "null_resource" "install_glfs" {
+  depends_on = [
+    "null_resource.provision_storage_mounts",
+  ]
+
+  # Don't install if there aren't enough storage nodes in use
+  count = "${var.storage_node_count > 1 ? 1 : 0}"
+
+  connection {
+    user        = "ubuntu"
+    private_key = "${file("${var.privkey}")}"
+    host        = "${openstack_networking_floatingip_v2.masterip.address}"
+  }
+
+  provisioner "file" {
+    source  = "assets/glfs"
+    destination = "/home/ubuntu"
+  }
+
+  provisioner "file" {
+    source  = "assets/deploy-glfs.sh"
+    destination = "/home/ubuntu/deploy-glfs.sh"
+  }
+  
+  provisioner "remote-exec" {
+    inline = [
+      "chmod +x /home/ubuntu/deploy-glfs.sh",
+      "/home/ubuntu/deploy-glfs.sh ${var.storage_node_count}"
     ]
   }
 }

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ on the more specific value domains.
  |worker_count | How many workers to provision |
  | worker_ips_count | How many of the workers should be assigned an external IP address? |
  | docker_volume_size | All nodes will have external block storage attached to use as the docker storage base (/var/lib/docker). Specify the size for these volumes in GBytes |
- | storage_node_count | You can optionally provision nodes to host CEPH shared storage. This needs to be an even number. |
+ | storage_node_count | You can optionally provision nodes to host shared storage. 0 => no PVC support, 1 => NFS-backed PVC, 2+ => GlusterFS-backed PVCs [see below](README.md#nfs-provisioner) |
  | storage_node_volume_size | Specify the size of the storage attached to each storage node. Expressed in GBytes |
  | dns_nameservers | A list of IP addresses of DNS name servers available to the new subnet |
 
@@ -78,9 +78,20 @@ on the more specific value domains.
  labeled `external_ip=true`.
 
 ### NFS Provisioner
-If you configured a storage node, it will be provisioned to run the NFS
-provisioner. This will run a lightweight NFS server in your cluster for
+If you configured a single storage node, it will be provisioned to run the
+[NFS Provisioner](https://github.com/kubernetes-incubator/external-storage/tree/master/nfs).
+This will run a lightweight NFS server in your Kubernetes cluster for
 persistent volume claim support.
+
+### GlusterFS Provisioner
+If you configured 2 or more storage nodes, they will be provisioned to run the
+[GlusterFS Simple Provisioner](https://github.com/kubernetes-incubator/external-storage/tree/master/gluster/glusterfs).
+This will run a distributed, scalable GlusterFS cluster in your Kubernetes
+cluster for persistent volume claim support.
+
+NOTE: Many (if not all) GlusterFS volume configurations will require an even
+number of storage nodes. We do not support odd-numbered values > 2 for
+`storage_node_count`.
 
 # Resizing the cluster
 Terraform makes this easy. Just adjust the values for the number of worker nodes

--- a/assets/deploy-glfs.sh
+++ b/assets/deploy-glfs.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+#
+# Usage: ./deploy-glfs.sh <number_of_storage_nodes>
+# 
+
+# DEBUG ONLY: Set this to "echo" to neuter the script and perform a dry-run
+DEBUG=""
+
+# The host directory to store brick files
+BRICK_HOSTDIR="/tmp"
+
+# Read in the desired number of storage nodes from first arg
+NODE_COUNT="$1"
+
+# Ensure that we have enough storage nodes to run GLFS
+if [ "$NODE_COUNT" -lt 2 ]; then
+  echo "ERROR: Cannot deploy GlusterFS with less than 2 nodes"
+  exit 1
+fi
+
+# Label storage nodes appropriately
+STORAGE_NODES=$(kubectl get nodes --no-headers | grep storage | awk '{print $1}')
+for node in $STORAGE_NODES; do
+  $DEBUG kubectl label nodes $node storagenode=glusterfs 
+done
+
+# Create the GLFS cluster
+$DEBUG kubectl apply -f glfs/glusterfs-daemonset.yaml
+
+# Wait for the GLFS cluster to come up
+count="$(kubectl get pods --no-headers | grep glusterfs | grep -v provisioner | awk '{print $3}' | grep Running | wc -l)"
+while [ "$count" -lt "$NODE_COUNT" ]; do
+  echo "Waiting for GLFS: $count / $NODE_COUNT"
+  sleep 5
+  count="$(kubectl get pods --no-headers | grep glusterfs | grep -v provisioner | awk '{print $3}' | grep -o Running | wc -l)"
+done
+echo "GlusterFS is now Running: $count / $NODE_COUNT"
+
+# Retrieve GlusterFS pod IPs
+PEER_IPS=$(kubectl get pods -o wide | grep glusterfs | grep -v provisioner | awk '{print $6}')
+
+# Use pod names / IPs to exec in and perform `gluster peer probe`
+for pod_ip in ${PEER_IPS}; do
+  for peer_ip in ${PEER_IPS}; do
+    # Skip each node probing itself
+    if [ "$pod_ip" == "$peer_ip" ]; then
+      continue;
+    fi
+
+    # Perform a gluster peer probe
+    pod_name=$(kubectl get pods -o wide | grep $pod_ip | awk '{print $1}')
+    $DEBUG kubectl exec -it $pod_name gluster peer probe $peer_ip
+  done;
+done;
+
+# Dynamically build StorageClass from pod IPs (see below)
+BRICK_PATHS=""
+for pod_ip in ${PEER_IPS[@]}; do
+  # Insert comma if we already started accumlating ips/paths
+  if [ "$BRICK_PATHS" != "" ]; then
+    BRICK_PATHS="$BRICK_PATHS,"
+  fi
+
+  # Build up brickrootPaths one host at a time
+  BRICK_PATHS="${BRICK_PATHS}${pod_ip}:${BRICK_HOSTDIR}"
+done
+
+# Modify StorageClass to contain our GlusterFS brickrootPaths
+echo "---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: glusterfs-simple
+provisioner: gluster.org/glusterfs-simple
+parameters:
+  forceCreate: \"true\"
+  volumeType: \"replica 2\"
+  brickrootPaths: \"$BRICK_PATHS\"
+" > glfs/storageclass.yaml
+
+# Create the storage class
+$DEBUG kubectl apply -f glfs/storageclass.yaml
+
+# Bind the necessary ServiceAccount / ClusterRole
+$DEBUG kubectl apply -f glfs/rbac.yaml
+
+# Create the GLFS Simple Provisioner
+$DEBUG kubectl apply -f glfs/deployment.yaml

--- a/assets/glfs/deployment.yaml
+++ b/assets/glfs/deployment.yaml
@@ -1,0 +1,18 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: glusterfs-simple-provisioner
+  namespace: kube-system
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: glusterfs-simple-provisioner
+    spec:
+      serviceAccount: glfs-provisioner
+      containers:
+        - image: "quay.io/external_storage/glusterfs-simple-provisioner:latest"
+          name: glusterfs-simple-provisioner

--- a/assets/glfs/glusterfs-daemonset.yaml
+++ b/assets/glfs/glusterfs-daemonset.yaml
@@ -1,0 +1,101 @@
+---
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: glusterfs
+  labels:
+    glusterfs: daemonset
+  annotations:
+    description: GlusterFS DaemonSet
+    tags: glusterfs
+spec:
+  template:
+    metadata:
+      name: glusterfs
+      labels:
+        glusterfs-node: pod
+    spec:
+      nodeSelector:
+        storagenode: glusterfs
+      hostNetwork: true
+      containers:
+      - image: gluster/gluster-centos:latest
+        imagePullPolicy: IfNotPresent
+        name: glusterfs
+        volumeMounts:
+        - name: glusterfs-heketi
+          mountPath: "/var/lib/heketi"
+        - name: glusterfs-run
+          mountPath: "/run"
+        - name: glusterfs-lvm
+          mountPath: "/run/lvm"
+        - name: glusterfs-etc
+          mountPath: "/etc/glusterfs"
+        - name: glusterfs-logs
+          mountPath: "/var/log/glusterfs"
+        - name: glusterfs-config
+          mountPath: "/var/lib/glusterd"
+        - name: glusterfs-dev
+          mountPath: "/dev"
+        - name: glusterfs-misc
+          mountPath: "/var/lib/misc/glusterfsd"
+        - name: glusterfs-cgroup
+          mountPath: "/sys/fs/cgroup"
+          readOnly: true
+        - name: glusterfs-ssl
+          mountPath: "/etc/ssl"
+          readOnly: true
+        securityContext:
+          capabilities: {}
+          privileged: true
+        readinessProbe:
+          timeoutSeconds: 3
+          initialDelaySeconds: 40
+          exec:
+            command:
+            - "/bin/bash"
+            - "-c"
+            - systemctl status glusterd.service
+          periodSeconds: 25
+          successThreshold: 1
+          failureThreshold: 15
+        livenessProbe:
+          timeoutSeconds: 3
+          initialDelaySeconds: 40
+          exec:
+            command:
+            - "/bin/bash"
+            - "-c"
+            - systemctl status glusterd.service
+          periodSeconds: 25
+          successThreshold: 1
+          failureThreshold: 15
+      volumes:
+      - name: glusterfs-heketi
+        hostPath:
+          path: "/var/lib/heketi"
+      - name: glusterfs-run
+      - name: glusterfs-lvm
+        hostPath:
+          path: "/run/lvm"
+      - name: glusterfs-etc
+        hostPath:
+          path: "/etc/glusterfs"
+      - name: glusterfs-logs
+        hostPath:
+          path: "/var/log/glusterfs"
+      - name: glusterfs-config
+        hostPath:
+          path: "/var/lib/glusterd"
+      - name: glusterfs-dev
+        hostPath:
+          path: "/dev"
+      - name: glusterfs-misc
+        hostPath:
+          path: "/var/lib/misc/glusterfsd"
+      - name: glusterfs-cgroup
+        hostPath:
+          path: "/sys/fs/cgroup"
+      - name: glusterfs-ssl
+        hostPath:
+          path: "/etc/ssl"

--- a/assets/glfs/rbac.yaml
+++ b/assets/glfs/rbac.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: glfs-provisioner
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: glfs-provisioner-runner
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events", "pods/exec"]
+    verbs: ["create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: run-glfs-provisioner
+subjects:
+  - kind: ServiceAccount
+    name: glfs-provisioner
+    namespace: kube-system
+# update namespace above to your namespace in order to make this work
+roleRef:
+  kind: ClusterRole
+  name: glfs-provisioner-runner
+  apiGroup: rbac.authorization.k8s.io

--- a/assets/glfs/storageclass.yaml
+++ b/assets/glfs/storageclass.yaml
@@ -1,0 +1,13 @@
+### WARNING: This file is dynamically generated and will be overwritten by deploy-glfs.sh ###
+### DO NOT manually edit this file. ###
+### DO NOT manually edit this file. ###
+### DO NOT manually edit this file. ###
+
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: glusterfs-simple
+provisioner: gluster.org/glusterfs-simple
+parameters:
+  forceCreate: "true"
+  brickrootPaths: "{{ BRICK_PATHS }}"

--- a/assets/glfs/test.pvc.yaml
+++ b/assets/glfs/test.pvc.yaml
@@ -1,0 +1,12 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: gluster-simple-claim
+  annotations:
+    volume.beta.kubernetes.io/storage-class: "glusterfs-simple"
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi


### PR DESCRIPTION
# Problem
Rook is not stable or mature enough to rely on for shared storage. It does not scale and cannot be easily resized after creation.

# Approach

Adds support for the [GlusterFS Simple Provisioner](https://github.com/kubernetes-incubator/external-storage/tree/master/gluster/glusterfs) under the right conditions:
* When `storage_node_count == 0`, no PVC support will be included by default
* When `storage_node_count == 1`, the NFS provisioner will be deployed
* When `storage_node_count >= 2`, the GlusterFS provisioner will be deployed

NOTE: This PR includes changes from #4, which should be merged first.

# How to test

1. Edit `variables.tf` and adjust `storage_node_count` to 2
2. Execute `terraform init && terraform apply`
3. Wait for your cluster to come up
4. SSH into the master node
5. Execute `kubectl create -f glfs/test.pvc.yaml`
6. Execute `kubectl get pvc,pv`
    * After a few seconds, you should see that your PVC has caused the creation of a new PV