### PR TITLE
Enable kubectl bash completion on master node

### DIFF
--- a/assets/bootstrap-master.sh
+++ b/assets/bootstrap-master.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 cd ~/kubeadm-bootstrap
 sudo -E ./init-master.bash
+
+# Enable kubectl bash completion on on master
+cat > /etc/bash_completion.d/kubectl << __EOF__
+source <(kubectl completion bash)
+__EOF__


### PR DESCRIPTION
# Problem
Fixes #6 - Shell completion is not installed by default.

# Approach
Add shell completion for bash during `assets/bootstrap-master.sh`.

# How to test

1. Execute `terraform init && terraform apply`
2. Wait for your cluster to come up
3. SSH into the master node
4. Enter a partial `kubectl` command and press <TAB>
    * You should see that `kubectl` now attempts to autocomplete namespaces and resource types/names when <TAB> is pressed