### PR TITLE
Copy kubectl completions to /etc/bash_completion.d as root

### DIFF
--- a/assets/bootstrap-master.sh
+++ b/assets/bootstrap-master.sh
@@ -3,6 +3,8 @@ cd ~/kubeadm-bootstrap
 sudo -E ./init-master.bash
 
 # Enable kubectl bash completion on on master
-cat > /etc/bash_completion.d/kubectl << __EOF__
+cat > kubectl << __EOF__
 source <(kubectl completion bash)
 __EOF__
+
+sudo mv kubectl /etc/bash_completion.d/kubectl


### PR DESCRIPTION
# Problem
Terraform fails during `bootstrap-master.sh` execution, reporting an _access denied_ failure. This is due to the `cat` of the completions config to `/etc/bash_completion.d/kubectl` lacking permission. 

# Approach
when executing `sudo cat >` , the pipe operator is not run as sudo, but as ubuntu, so the simple change doesn't fix this.  I made this explicit by writing the completions to a file in the home directory and then using `sudo mv` to put the file in the protected directory.

# How to test
Just run a full terraform apply and see that the completions are applied.

