### PR TITLE
Change bootstrap-master to inline exec

### DIFF
--- a/05_provision_master.tf
+++ b/05_provision_master.tf
@@ -34,19 +34,21 @@ resource "null_resource" "provision_master" {
     source  = "assets/bootstrap.sh"
     destination = "/home/ubuntu/bootstrap.sh"
   }
+  provisioner "file" {
+    source  = "assets/bootstrap-master.sh"
+    destination = "/home/ubuntu/bootstrap-master.sh"
+  } 
   provisioner "remote-exec" {
     inline = [
+      "sleep 60",
       "chmod +x /home/ubuntu/bootstrap.sh",
-      "/home/ubuntu/bootstrap.sh"
+      "/home/ubuntu/bootstrap.sh",
+      "chmod +x /home/ubuntu/bootstrap-master.sh",
+      "/home/ubuntu/bootstrap-master.sh ${var.pod_network_type}"
     ]
   }
 
   provisioner "remote-exec" {
-    script = "assets/bootstrap-master.sh ${var.pod_network_type}"
-  }
-
-  provisioner "remote-exec" {
-    inline = ["kubectl label node ${var.env_name}-master external_ip=true"
-]
+    inline = ["kubectl label node ${var.env_name}-master external_ip=true"]
   }
 }


### PR DESCRIPTION
**Problem**
The `remote-exec` script approach requires that the called script have no argument. With the `weave` argument, it fails with a file not found error.

**Solution**
Change to use the `remote-exec` inline after copying the file to the host.

Note: I've added the 60 second sleep because of a problem I'm seeing on Jetstream during provisioning. I've repeatedly seen an apt lock prevent the installation of Docker during bootstrap that seems to be resolved with the sleep.

**Test**
* Checkout this branch
* Provision a cluster with weave
* Confirm provision succeeds