### PR TITLE
Small fixes discovered during new cheesehub prod deployment

### DIFF
--- a/assets/bootstrap-master.sh
+++ b/assets/bootstrap-master.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 cd ~/kubeadm-bootstrap
+
+echo '============================'
+echo '= Provsioning Master Node  ='
+echo '============================'
 sudo -E ./init-master.bash $1
 
 # Enable kubectl bash completion on on master

--- a/assets/bootstrap.sh
+++ b/assets/bootstrap.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
+echo '============================'
+echo '= Installing kubeadm       ='
+echo '============================'
 cd ~
-git clone https://github.com/nds-org/kubeadm-bootstrap
+git clone https://github.com/nds-org/kubeadm-bootstrap -b bootstrapping-fixup
 cd kubeadm-bootstrap
 sudo ./install-kubeadm.bash
 
-sudo apt-get install -y jq nfs-common
+
+echo '============================'
+echo '= Updating OS Dependencies ='
+echo '============================'
+sudo apt-get update -qq
+sudo apt-get upgrade -qq
+sudo apt-get install -qq jq nfs-common

--- a/assets/bootstrap.sh
+++ b/assets/bootstrap.sh
@@ -3,7 +3,7 @@ echo '============================'
 echo '= Installing kubeadm       ='
 echo '============================'
 cd ~
-git clone https://github.com/nds-org/kubeadm-bootstrap -b bootstrapping-fixup
+git clone https://github.com/nds-org/kubeadm-bootstrap
 cd kubeadm-bootstrap
 sudo ./install-kubeadm.bash
 

--- a/assets/deploy-nfs.sh
+++ b/assets/deploy-nfs.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # Create the NFS storage class
-kubectl create -f nfs/storageclass.yaml
+kubectl apply -f nfs/storageclass.yaml
 
 # Deploy RBAC role/binding
-kubectl create -f nfs/rbac.yaml
+kubectl apply -f nfs/rbac.yaml
 
 # Create the NFS provisioner
-kubectl create -f nfs/deployment.yaml
+kubectl apply -f nfs/deployment.yaml

--- a/assets/deploy-nfs.sh
+++ b/assets/deploy-nfs.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+echo '============================='
+echo '= Deploying NFS Provisioner ='
+echo '============================='
+
 # Create the NFS storage class
 kubectl apply -f nfs/storageclass.yaml
 

--- a/assets/nfs/deployment.yaml
+++ b/assets/nfs/deployment.yaml
@@ -12,16 +12,44 @@ metadata:
   labels:
     app: nfs-provisioner
 spec:
+  # {111 TCP}:true {111 UDP}:true {662 TCP}:true {662 UDP}:true {875 TCP}:true {875 UDP}:true {2049 TCP}:true {2049 UDP}:true {20048 TCP}:true {20048 UDP}:true {32803 TCP}:true {32803 UDP}:true
   ports:
     - name: nfs
       port: 2049
+    - name: nfs-udp
+      port: 2049
+      protocol: UDP
+
     - name: mountd
       port: 20048
+    - name: mountd-udp
+      port: 20048
+      protocol: UDP
+
     - name: rpcbind
       port: 111
     - name: rpcbind-udp
       port: 111
       protocol: UDP
+
+    - name: newporta
+      port: 662
+    - name: newporta-udp
+      port: 662
+      protocol: UDP
+
+    - name: newportb
+      port: 32803
+    - name: newportb-udp
+      port: 32803
+      protocol: UDP
+
+    - name: newportc
+      port: 875
+    - name: newportc-udp
+      port: 875
+      protocol: UDP
+
   selector:
     app: nfs-provisioner
 ---
@@ -43,19 +71,49 @@ spec:
         app: nfs-provisioner
     spec:
       serviceAccount: nfs-provisioner
+      nodeSelector:
+        external-storage: "true"
       containers:
         - name: nfs-provisioner
           image: quay.io/kubernetes_incubator/nfs-provisioner:latest
           ports:
+            # {111 TCP}:true {111 UDP}:true {662 TCP}:true {662 UDP}:true {875 TCP}:true {875 UDP}:true {2049 TCP}:true {2049 UDP}:true {20048 TCP}:true {20048 UDP}:true {32803 TCP}:true {32803 UDP}:true
             - name: nfs
               containerPort: 2049
+            - name: nfs-udp
+              containerPort: 2049
+              protocol: UDP
+
             - name: mountd
               containerPort: 20048
+            - name: mountd-udp
+              containerPort: 20048
+              protocol: UDP
+
             - name: rpcbind
               containerPort: 111
             - name: rpcbind-udp
               containerPort: 111
               protocol: UDP
+
+            - name: newporta
+              containerPort: 662
+            - name: newporta-udp
+              containerPort: 662
+              protocol: UDP
+
+            - name: newportb
+              containerPort: 32803
+            - name: newportb-udp
+              containerPort: 32803
+              protocol: UDP
+
+            - name: newportc
+              containerPort: 875
+            - name: newportc-udp
+              containerPort: 875
+              protocol: UDP
+
           securityContext:
             capabilities:
               add:

--- a/provision/main.tf
+++ b/provision/main.tf
@@ -91,14 +91,6 @@ resource "null_resource" "worker_join" {
     "sudo ${var.k8s_join_command}"
     ]
   }
-
-  ## Perform some cleanup when we destroy the node
-  provisioner "remote-exec" {
-    when = "destroy"
-    inline = [
-      "sudo kubeadm reset"
-    ]
-  }
 }
 
 ## This null resource just has a provisioner step that runs on the master


### PR DESCRIPTION
## Problem
Terraform deploy is stale, and hasn't been tested with newer versions of kubeadm

## Approach
* Wait for cloud-init to finish before running `.sudo /install-kubeadm.bash`
* Avoid running `kubeadm destroy` when we are destroying the entire cluster
* Expose new ports, update to newer NFS server provisioner version (custom, not Helm chart, so the data is actually persisted)
* Added some helpful debug output to tell the different phases apart

## How to Test
1. Checkout and run this branch locally
2. Download OpenRC.sh from target OpenStack API (via Horizon dashboard)
3. `source openrc.sh` on your deploy machine
4. Download terraform binary
5. Run `terraform init` to download plugins/modules/providers/whatever
6. Run `terraform apply` and type `yes` to confirm and provision the cluster
7. Wait for terraform to finish running
8. SSH into master and run `kubectl get pods -A`, confirm that all is running:
  * DNS
  * NFS provisioner
  * NGINX Ingress Controller
  * Kubernetes internal Components (etcd, apiserver, etc)